### PR TITLE
Allow chaining with_content predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,23 @@ You can use any RSpec content matcher inside of the `with_content` predicate:
 expect(chef_run).to render_file('/etc/foo').with_content(start_with('# First line'))
 ```
 
+You can chain `with_content` predicates together:
+
+```ruby
+expect(chef_run).to render_file('/etc/foo').with_content('This').with_content('content')
+```
+
+Prefer using a block to chaining `with_content` predicates, e.g. replace the above with:
+
+```ruby
+expect(chef_run).to render_file('/etc/foo').with_content { |content |
+  expect(content).to include('This')
+  expect(content).to include('content')
+}
+```
+
+#### execution phase
+
 It is possible to assert which [Chef phase of execution](https://docs.chef.io/chef_client.html#the-chef-client-title-run) a resource is created. Given a resource that is installed at compile time using `run_action`:
 
 ```ruby

--- a/examples/render_file/spec/default_spec.rb
+++ b/examples/render_file/spec/default_spec.rb
@@ -74,6 +74,17 @@ describe 'render_file::default' do
           end_with('not')
         )
       end
+
+      it 'renders the file with chained content matchers' do
+        expect(chef_run).to render_file('/tmp/cookbook_file')
+          .with_content('This')
+          .with_content('is')
+          .with_content('content!')
+        expect(chef_run).to_not render_file('/tmp/cookbook_file')
+          .with_content('Sparta!')
+          .with_content('is')
+          .with_content('This')
+      end
     end
 
     context 'with a pristine filesystem' do

--- a/spec/unit/matchers/render_file_matcher_spec.rb
+++ b/spec/unit/matchers/render_file_matcher_spec.rb
@@ -12,7 +12,7 @@ describe ChefSpec::Matchers::RenderFileMatcher do
       expect(
         subject.with_content do |content|
           'Does not raise ArgumentError'
-        end.expected_content.call
+        end.expected_content.first.call
       ).to eq('Does not raise ArgumentError')
     end
   end
@@ -37,6 +37,13 @@ describe ChefSpec::Matchers::RenderFileMatcher do
     it 'has the right value' do
       subject.matches?(chef_run)
       expect(subject.description).to eq(%Q(render file "#{path}"))
+    end
+
+    it 'has the right value when with_content is chained' do
+      subject.matches?(chef_run)
+      expect(
+        subject.with_content('foo').with_content('bar').description
+      ).to eq(%Q(render file "#{path}" with content "foo" with content "bar"))
     end
   end
 


### PR DESCRIPTION
I will write something such as

``` ruby
expect(chef_run).to render_file('/etc/foo').with_content('bar')
```

then I come along later to add another check:

``` ruby
expect(chef_run).to render_file('/etc/foo')
  .with_content('bar')
  .with_content('something else entirely')
```

It's very surprising to discover that `with_content('bar')` is ignored.

The choices are to make it an error to chain `.with_content` together, to emit some warning, or to regard it as valid usage. I rejected a warning as not very useful and an error as aggressively unhelpful. Any tests inadvertently using chained `with_content` will probably still pass, so we don't want to suddenly break them.
