### PR TITLE
Support to specify policy_name/group to use in test

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,28 +189,47 @@ cookbook 'name_of_your_cookbook', path: '.'
 
 ### Policyfile
 
-If you are using Chef Policies with ChefDK, simply require `chefspec/policyfile` in your `spec_helper`, and ensure you are using the `ChefSpec::ServerRunner` - Chef Solo does not support the exported repository format because the cookbook names use the unique version identifier.
+If you are using Chef Policies with ChefDK, ensure you are using the `ChefSpec::ServerRunner` - Chef Solo does not support the exported repository format because the cookbook names use the unique version identifier.
+Simply specify the `policy_name` option to the runner.
 
 ```ruby
 # spec_helper.rb
 require 'chefspec'
-require 'chefspec/policyfile'
 ```
 
-Requiring this file will:
+```ruby
+require 'spec_helper'
 
-- Create a temporary working directory
-- Download all the dependencies listed in your `Policyfile.rb` into the temporary directory
-- Set ChefSpec's `cookbook_path` to the temporary directory
+describe 'my_policy_name' do
+  context 'When all attributes are default, on centos' do
+    cached(:chef_run) do
+      runner = ChefSpec::ServerRunner.new(
+        platform: 'centos',
+        version: '7.2.1511',
+        policy_name: described_policy,
+      )
+      runner.converge
+    end
 
-Your `Policyfile.rb` should look something like this:
+    it 'converges correctly' do
+      expect { chef_run }.to_not raise_error
+    end
+  end
+end
+```
+
+You can also specify the `policy_group` option.
+
+Your policyfile should be named `my_policy_name.rb` should look something like this:
 
 ```ruby
-name 'my-cookbook'
+name 'my_policy_name'
 run_list 'my-cookbook::default'
 default_source :community
 cookbook 'my-cookbook', path: '.'
 ```
+
+Directory where policies are found is configurable with `policy_path` RSpec option.
 
 ## Running Specs
 

--- a/lib/chefspec/macros.rb
+++ b/lib/chefspec/macros.rb
@@ -52,6 +52,26 @@ module ChefSpec
     end
 
     #
+    # The name of the currently running policy spec. Given the top-level
+    # +describe+ block is of the format:
+    #
+    #     describe 'my_policy::my_named_run_list' do
+    #       # ...
+    #     end
+    #
+    # The value of +described_recipe+ is "my_policy".
+    #
+    # @example Using +described_recipe+ in the +ChefSpec::ServerRunner+
+    #   let(:chef_run) { ChefSpec::ServerRunner.new.converge(described_recipe) }
+    #
+    #
+    # @return [String]
+    #
+    def described_policy
+      described_cookbook
+    end
+
+    #
     # Stub a shell command to return a particular value without
     # shelling out to the system.
     #

--- a/lib/chefspec/rspec.rb
+++ b/lib/chefspec/rspec.rb
@@ -15,6 +15,7 @@ RSpec.configure do |config|
   config.add_setting :role_path
   config.add_setting :environment_path
   config.add_setting :file_cache_path
+  config.add_setting :policy_path, default: Dir.pwd
   config.add_setting :log_level, default: :warn
   config.add_setting :path
   config.add_setting :platform


### PR DESCRIPTION
- add policy_path config option, default to current directory
- allow to specify which policy_name & group to use
- add a small helper `described_policy`

This patch currently break the previous behavior of requiring
chefspec/policyfile.
Previously: it would load and converge policy defined in Policyfile.rb
Now: there is no need to require chefspec/policyfile but to specify `policy_name`
     as an option of the ServerRunner class.

Fixes #801 