### PR TITLE
allow render_file to ignore certain whitespace in file

### DIFF
--- a/examples/render_file/recipes/default.rb
+++ b/examples/render_file/recipes/default.rb
@@ -13,3 +13,7 @@ end
 template '/tmp/partial' do
   source 'partial.erb'
 end
+
+template '/tmp/whitespace_template' do
+  source 'whitespace_template.erb'
+end

--- a/examples/render_file/spec/default_spec.rb
+++ b/examples/render_file/spec/default_spec.rb
@@ -116,6 +116,13 @@ describe 'render_file::default' do
       }
     end
 
+    it 'ignores certain whitespace when strip_content is specified' do
+      expect(chef_run).to render_file('/tmp/whitespace_template').with_content(
+        "There was whitespace before this line...\n  after these words...\nand after this line",
+        strip_content: true
+      )
+    end
+
     it 'renders the file with content matching arbitrary matcher' do
       expect(chef_run).to render_file('/tmp/template').with_content(
         start_with('This')

--- a/examples/render_file/templates/default/whitespace_template.erb
+++ b/examples/render_file/templates/default/whitespace_template.erb
@@ -1,0 +1,1 @@
+<%= "  \n\r\n\t\nThere was whitespace before this line...\n  after these words...  \t\nand after this line\n\r\n\n" %>

--- a/lib/chefspec/api/render_file.rb
+++ b/lib/chefspec/api/render_file.rb
@@ -17,6 +17,9 @@ module ChefSpec::API
   # @example Assert a template is rendered with content matching any RSpec matcher
   #   expect(template).to render_file('/etc/foo').with_content(starts_with('This'))
   #
+  # @example Assert a template is rendered with content ignoring leading and trailing whitespace lines, and trailing whitespace on each line
+  #   expect(template).to render_file('/etc/foo').with_content('This is a file', strip_content: true)
+  #
   # @example Assert a partial path to a template is rendered with matching content
   #   expect(template).to render_file(/\/etc\/foo-(\d+)$/).with_content(/^This(.+)$/)
   #

--- a/lib/chefspec/matchers/render_file_matcher.rb
+++ b/lib/chefspec/matchers/render_file_matcher.rb
@@ -16,11 +16,15 @@ module ChefSpec::Matchers
       end
     end
 
-    def with_content(expected_content = nil, &block)
+    def with_content(expected_content = nil, strip_content: false, &block)
       if expected_content && block
         raise ArgumentError, "Cannot specify expected content and a block!"
       elsif expected_content
-        @expected_content = expected_content
+        @expected_content = if strip_content
+                              Util.remove_config_file_whitespace(expected_content)
+                            else
+                              expected_content
+                            end
       elsif block_given?
         @expected_content = block
       else

--- a/lib/chefspec/util.rb
+++ b/lib/chefspec/util.rb
@@ -54,5 +54,22 @@ module ChefSpec
         string
       end
     end
+
+    #
+    # Remove leading and trailing blank lines, and trailing whitespace from each
+    # line. This is useful for matching the content in a config file, when this
+    # whitespace doesn't typically matter.
+    #
+    # @param [String] string
+    #   the string to trim whitespace off of
+    #
+    def remove_config_file_whitespace(string)
+      lines = string.lines
+      # remove leading and trailing blank lines
+      lines.shift while lines.first.strip.empty?
+      lines.pop while lines.last.strip.empty?
+      # remove trailing whitespace from lines
+      lines.map(&:rstrip).join("\n")
+    end
   end
 end

--- a/spec/unit/util_spec.rb
+++ b/spec/unit/util_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+require 'chefspec/util'
+
+describe ChefSpec::Util do
+  let(:config_file_with_whitespace) do
+    "
+\t
+    blue
+
+  green \t
+    4
+  \r\n
+"
+  end
+
+  it 'remove_config_file_whitespace removes config file whitespace' do
+    expect(
+      ChefSpec::Util.remove_config_file_whitespace(config_file_with_whitespace)
+    ).to eq("    blue\n\n  green\n    4")
+  end
+end


### PR DESCRIPTION
I had a use for this today when matching a generated haproxy config file to a version of the generated file we keep in `/spec/support/`. We match the file contents like so:

```ruby
expect(chef_run).to render_file('/etc/haproxy/haproxy.cfg').with_content(
  File.read('spec/chef-fixtures/haproxy.cfg')
)
```

But our unit tests would fail sometimes with messages like (content shortened):

```
Failures:

  1) our_cookbook::haproxy should render haproxy.cfg with content
     Failure/Error:
       expect(chef_run).to render_file('/etc/haproxy/haproxy.cfg').with_content(
         File.read('spec/chef-fixtures/haproxy.cfg')
       )

       expected Chef run to render "/etc/haproxy/haproxy.cfg" matching:

       # Generated by Chef

       backend whatever
         balance source
         option httpchk
         server whatever_1 10.190.116.225:8888 check port 8888 weight 1 maxconn 100
         server whatever_2 10.190.159.80:8888 check port 8888 weight 1 maxconn 100

       backend stats_interface
         server local 0.0.0.0:8080
         stats enable 
         stats uri /
         stats realm Strictly\ Private



       but got:

       # Generated by Chef

       backend whatever
         balance source
         option httpchk
         server whatever_1 10.190.116.225:8888 check port 8888 weight 1 maxconn 100
         server whatever_2 10.190.159.80:8888 check port 8888 weight 1 maxconn 100

       backend stats_interface
         server local 0.0.0.0:8080
         stats enable
         stats uri /
         stats realm Strictly\ Private

     # ./spec/haproxy_spec.rb:78:in `block (2 levels) in <top (required)>'

```

Unfortunately these error messages aren't helpful for us seeing that `stats enable ` actually has a space at the end and the file we are comparing to has an extra blank line at the end.

I know that some rspec failures show a diff rather than `expected: a but got: b` - if thats possible to set up for these string comparisons then that would be wayyyy better than the solution I have presented here. If anyone knows how to do that please let me know.

Anyway, the solution I came up with should allow for something like:

```ruby
expect(chef_run).to render_file('/etc/haproxy/haproxy.cfg').with_content(
  File.read('spec/chef-fixtures/haproxy.cfg'),
  strip_content: true
)
```

The benefit here is my spec will only fail with differences that haproxy considers grievous - whitespace at the beginning or end of the file and at the end of lines should not matter. I think this is the case for several config parsers, not just haproxy, so I thought I'd try to contribute this back.

If maintainers feel this is not useful and just extra code to maintain, or is a questionable approach in general, thats fine. I kind of just wanted to see if I could do this anyway.