### PR TITLE
Make Berksfile path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ RSpec.configuration do |config|
 end
 ```
 
-This is a Ruby hash and valid options include `only` and `except`.
+This is a Ruby hash and valid options include `berksfile`, `only` and `except`.
 
 ### Librarian
 

--- a/lib/chefspec/berkshelf.rb
+++ b/lib/chefspec/berkshelf.rb
@@ -27,7 +27,7 @@ module ChefSpec
         raise InvalidBerkshelfOptions(value: opts.inspect)
       end
 
-      berksfile = ::Berkshelf::Berksfile.from_file('Berksfile', opts)
+      berksfile = ::Berkshelf::Berksfile.from_options(opts)
 
       # Grab a handle to tmpdir, since Berkshelf 2 modifies it a bit
       tmpdir = File.join(@tmpdir, 'cookbooks')


### PR DESCRIPTION
In berkshelf.rb, replace 'from_file' by 'from_options'.
- This allows to specify the path on Berksfile by configuring the
'berksfile' entry in berkshelf_options. It is useful in particular
if we manage several cookbooks in a single Chef repository (so with a
common Berksfile).
- By the way, from a programmatic point of view, it removes a magic value
(the default name of the Berksfile) that is already given by Berkshelf
module.