### PR TITLE
Update examples to use non-deprecated platforms

### DIFF
--- a/examples/openbsd_package/spec/install_spec.rb
+++ b/examples/openbsd_package/spec/install_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'openbsd_package::install' do
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'openbsd', version: '5.4').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'openbsd', version: '6.2').converge(described_recipe) }
 
   it 'installs a openbsd_package with the default action' do
     expect(chef_run).to install_openbsd_package('default_action')

--- a/examples/openbsd_package/spec/purge_spec.rb
+++ b/examples/openbsd_package/spec/purge_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'openbsd_package::purge' do
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'openbsd', version: '5.4').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'openbsd', version: '6.2').converge(described_recipe) }
 
   it 'purges a openbsd_package with an explicit action' do
     expect(chef_run).to purge_openbsd_package('explicit_action')

--- a/examples/openbsd_package/spec/remove_spec.rb
+++ b/examples/openbsd_package/spec/remove_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'openbsd_package::remove' do
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'openbsd', version: '5.4').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'openbsd', version: '6.2').converge(described_recipe) }
 
   it 'removes a openbsd_package with an explicit action' do
     expect(chef_run).to remove_openbsd_package('explicit_action')

--- a/examples/openbsd_package/spec/upgrade_spec.rb
+++ b/examples/openbsd_package/spec/upgrade_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'openbsd_package::upgrade' do
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'openbsd', version: '5.4').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'openbsd', version: '6.2').converge(described_recipe) }
 
   it 'upgrades a openbsd_package with an explicit action' do
     expect(chef_run).to upgrade_openbsd_package('explicit_action')

--- a/examples/pacman_package/spec/install_spec.rb
+++ b/examples/pacman_package/spec/install_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'pacman_package::install' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'arch', version: '4.9.11-1-ARCH')
+    ChefSpec::ServerRunner.new(platform: 'arch', version: '4.10.13-1-ARCH')
                           .converge(described_recipe)
   end
 

--- a/examples/pacman_package/spec/purge_spec.rb
+++ b/examples/pacman_package/spec/purge_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'pacman_package::purge' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'arch', version: '4.9.11-1-ARCH')
+    ChefSpec::ServerRunner.new(platform: 'arch', version: '4.10.13-1-ARCH')
                           .converge(described_recipe)
   end
 

--- a/examples/pacman_package/spec/remove_spec.rb
+++ b/examples/pacman_package/spec/remove_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'pacman_package::remove' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'arch', version: '4.9.11-1-ARCH')
+    ChefSpec::ServerRunner.new(platform: 'arch', version: '4.10.13-1-ARCH')
                           .converge(described_recipe)
   end
 

--- a/examples/pacman_package/spec/upgrade_spec.rb
+++ b/examples/pacman_package/spec/upgrade_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'pacman_package::upgrade' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'arch', version: '4.9.11-1-ARCH')
+    ChefSpec::ServerRunner.new(platform: 'arch', version: '4.10.13-1-ARCH')
                           .converge(described_recipe)
   end
 

--- a/examples/paludis_package/spec/install_spec.rb
+++ b/examples/paludis_package/spec/install_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'paludis_package::install' do
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'gentoo', version: '2.2').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'gentoo', version: '4.9.6-gentoo-r1').converge(described_recipe) }
 
   it 'installs a paludis_package with the default action' do
     expect(chef_run).to install_paludis_package('default_action')

--- a/examples/paludis_package/spec/purge_spec.rb
+++ b/examples/paludis_package/spec/purge_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'paludis_package::purge' do
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'gentoo', version: '2.2').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'gentoo', version: '4.9.6-gentoo-r1').converge(described_recipe) }
 
   it 'purges a paludis_package with an explicit action' do
     expect(chef_run).to purge_paludis_package('explicit_action')

--- a/examples/paludis_package/spec/remove_spec.rb
+++ b/examples/paludis_package/spec/remove_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'paludis_package::remove' do
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'gentoo', version: '2.2').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'gentoo', version: '4.9.6-gentoo-r1').converge(described_recipe) }
 
   it 'removes a paludis_package with an explicit action' do
     expect(chef_run).to remove_paludis_package('explicit_action')

--- a/examples/paludis_package/spec/upgrade_spec.rb
+++ b/examples/paludis_package/spec/upgrade_spec.rb
@@ -1,7 +1,7 @@
 require 'chefspec'
 
 describe 'paludis_package::upgrade' do
-  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'gentoo', version: '2.2').converge(described_recipe) }
+  let(:chef_run) { ChefSpec::SoloRunner.new(platform: 'gentoo', version: '4.9.6-gentoo-r1').converge(described_recipe) }
 
   it 'upgrades a paludis_package with an explicit action' do
     expect(chef_run).to upgrade_paludis_package('explicit_action')

--- a/examples/portage_package/spec/install_spec.rb
+++ b/examples/portage_package/spec/install_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'portage_package::install' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'gentoo', version: '2.2')
+    ChefSpec::ServerRunner.new(platform: 'gentoo', version: '4.9.6-gentoo-r1')
                           .converge(described_recipe)
   end
 

--- a/examples/portage_package/spec/purge_spec.rb
+++ b/examples/portage_package/spec/purge_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'portage_package::purge' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'gentoo', version: '2.2')
+    ChefSpec::ServerRunner.new(platform: 'gentoo', version: '4.9.6-gentoo-r1')
                           .converge(described_recipe)
   end
 

--- a/examples/portage_package/spec/remove_spec.rb
+++ b/examples/portage_package/spec/remove_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'portage_package::remove' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'gentoo', version: '2.2')
+    ChefSpec::ServerRunner.new(platform: 'gentoo', version: '4.9.6-gentoo-r1')
                           .converge(described_recipe)
   end
 

--- a/examples/portage_package/spec/upgrade_spec.rb
+++ b/examples/portage_package/spec/upgrade_spec.rb
@@ -2,7 +2,7 @@ require 'chefspec'
 
 describe 'portage_package::upgrade' do
   let(:chef_run) do
-    ChefSpec::ServerRunner.new(platform: 'gentoo', version: '2.2')
+    ChefSpec::ServerRunner.new(platform: 'gentoo', version: '4.9.6-gentoo-r1')
                           .converge(described_recipe)
   end
 


### PR DESCRIPTION
This way we avoid deprecation warnings during the test runs