### PR TITLE
Don't put an upper bound on the fauxhai version

### DIFF
--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.2'
 
   s.add_dependency 'chef',    '>= 12.14.89'
-  s.add_dependency 'fauxhai', '>= 4', '< 6'
+  s.add_dependency 'fauxhai', '>= 4'
   s.add_dependency 'rspec',   '~> 3.0'
 end


### PR DESCRIPTION
This avoids having to release chefspec every time we release a fauxhai
release that removes some platforms.

Signed-off-by: Tim Smith <tsmith@chef.io>