### PR TITLE
use the chef standard GEMFILE_MOD env var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,25 +16,24 @@ bundler_args: --jobs 7 --retry 3
 
 matrix:
   include:
-    - env: CHEF_VERSION=master
-      rvm: 2.5.0
-    - env: CHEF_VERSION=13.8.3
+    - rvm: 2.5.1
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 13.8.3'\""
       rvm: 2.4.3
-    - env: CHEF_VERSION=13.7.16
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 13.7.16'\""
       rvm: 2.4.3
-    - env: CHEF_VERSION=13.6.4
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 13.6.4'\""
       rvm: 2.4.2
-    - env: CHEF_VERSION=13.5.3
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 13.5.3'\""
       rvm: 2.4.2
-    - env: CHEF_VERSION=13.4.24
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 13.4.24'\""
       rvm: 2.4.2
-    - env: CHEF_VERSION=13.3.42
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 13.3.42'\""
       rvm: 2.4.2
-    - env: CHEF_VERSION=13.2.20
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 13.2.20'\""
       rvm: 2.4.2
-    - env: CHEF_VERSION=13.1.31
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 13.1.31'\""
       rvm: 2.4.2
-    - env: CHEF_VERSION=13.0.118
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 13.0.118'\""
       rvm: 2.4.2
-    - env: CHEF_VERSION=12.21.31
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 12.21.31'\""
       rvm: 2.3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,5 +35,3 @@ matrix:
       rvm: 2.4.2
     - env: "GEMFILE_MOD=\"gem 'chef', '= 13.0.118'\""
       rvm: 2.4.2
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 12.21.31'\""
-      rvm: 2.3.5

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,5 @@
 source 'https://rubygems.org'
 
-# env var for travis
-if ENV['CHEF_VERSION']
-  if ENV['CHEF_VERSION'] == "master"
-    gem 'chef', git: "https://github.com/chef/chef"
-    gem 'ohai', git: "https://github.com/chef/ohai"
-  else
-    gem 'chef', ENV['CHEF_VERSION']
-  end
-end
-
 gemspec
 
 group :development do
@@ -17,3 +7,15 @@ group :development do
   gem 'redcarpet'
   gem 'yard'
 end
+
+if ENV["GEMFILE_MOD"]
+  puts "GEMFILE_MOD: #{ENV['GEMFILE_MOD']}"
+  instance_eval(ENV["GEMFILE_MOD"])
+else
+  gem 'chef', git: "https://github.com/chef/chef"
+  gem 'ohai', git: "https://github.com/chef/ohai"
+end
+
+# If you want to load debugging tools into the bundle exec sandbox,
+# add these additional dependencies into Gemfile.local
+eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")


### PR DESCRIPTION
this should have the effect of allowing the travis tests in
chef/chef to test master of chef/chef against this repo on
every checkin now.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>