### PR TITLE
Change the freebsd monkeypatch to assume pkgng

### DIFF
--- a/lib/chefspec/extensions/chef/resource/freebsd_package.rb
+++ b/lib/chefspec/extensions/chef/resource/freebsd_package.rb
@@ -12,7 +12,7 @@ class Chef
       # @return [false]
       #
       def supports_pkgng?
-        false
+        true
       end
     end
   end


### PR DESCRIPTION
Without this FreeBSD package will start to trigger the deprecation
warnings and we'll get errors on that.

Signed-off-by: Tim Smith <tsmith@chef.io>