### PR TITLE
Fix ChefSpec injection with non-class-or-string describes

### DIFF
--- a/examples/core/recipes/default.rb
+++ b/examples/core/recipes/default.rb
@@ -1,0 +1,1 @@
+log 'Hello'

--- a/examples/core/spec/default_spec.rb
+++ b/examples/core/spec/default_spec.rb
@@ -1,0 +1,7 @@
+require 'chefspec'
+
+describe 'core' do
+  platform 'ubuntu'
+
+  it { is_expected.to write_log('Hello') }
+end

--- a/examples/core/spec/non_recipe_spec.rb
+++ b/examples/core/spec/non_recipe_spec.rb
@@ -1,0 +1,5 @@
+require 'chefspec'
+
+describe 1 do
+  it { is_expected.to eq 1 }
+end

--- a/lib/chefspec/api/core.rb
+++ b/lib/chefspec/api/core.rb
@@ -182,7 +182,7 @@ module ChefSpec
           klass.extend(ClassMethods)
           # If the describe block is aimed at string or resource/provider class
           # then set the default subject to be the Chef run.
-          if klass.described_class.nil? || klass.described_class < Chef::Resource || klass.described_class < Chef::Provider
+          if klass.described_class.nil? || klass.described_class.is_a?(Class) && (klass.described_class < Chef::Resource || klass.described_class < Chef::Provider)
             klass.subject { chef_run }
           end
         end


### PR DESCRIPTION
Discovered via a case in poise where I pass in a singleton constant that isn't a class.