### PR TITLE
Improve runner construction code

### DIFF
--- a/examples/spec_attributes/spec/default_spec.rb
+++ b/examples/spec_attributes/spec/default_spec.rb
@@ -51,4 +51,13 @@ describe 'spec_attributes' do
       it { is_expected.to write_log('thing1=un thing2=two version=3.0') }
     end
   end
+
+  context 'before attributes' do
+    before do
+      chefspec_default_attributes['myapp'] ||= {}
+      chefspec_default_attributes['myapp']['version'] = '4.0'
+    end
+
+    it { is_expected.to write_log('version=4.0') }
+  end
 end


### PR DESCRIPTION
Tweak the runner construction process a bit so the preload doesn't cache the runner object.

This allows setting before-level values that don't get lost in the shuffle.