### PR TITLE
Test on Chef 14.4 and update the URL in the gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ bundler_args: --jobs 7 --retry 3
 
 matrix:
   include:
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 14.4.56'\""
+      rvm: 2.5.1
     - env: "GEMFILE_MOD=\"gem 'chef', '= 14.3.37'\""
       rvm: 2.5.1
     - env: "GEMFILE_MOD=\"gem 'chef', '= 14.2.0'\""

--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
                     'ChefSpec makes it easy to write examples and get fast ' \
                     'feedback on cookbook changes without the need for ' \
                     'virtual machines or cloud servers.'
-  s.homepage      = 'https://sethvargo.github.io/chefspec/'
+  s.homepage      = 'https://github.com/chefspec/chefspec'
   s.license       = 'MIT'
 
   # Packaging


### PR DESCRIPTION
The homepage in the gemspec doesn't work anymore. Use the github repo.

Signed-off-by: Tim Smith <tsmith@chef.io>