### PR TITLE
Fix policyfile with chefserver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ bundler_args: --jobs 7 --retry 3
 
 matrix:
   include:
+    # special case to test ChefSpec with Policyfile
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 14.7.17'; gem 'chef-dk', '~> 3'\""
+      rvm: 2.5.3
     - env: "GEMFILE_MOD=\"gem 'chef', '= 14.7.17'\""
       rvm: 2.5.3
     - env: "GEMFILE_MOD=\"gem 'chef', '= 14.6.47'\""

--- a/examples/policy_file/Policyfile.rb
+++ b/examples/policy_file/Policyfile.rb
@@ -1,0 +1,7 @@
+name 'fake_policy_to_show_supermarket_works'
+
+default_source :supermarket
+
+run_list 'policy_file'
+
+cookbook 'policy_file', path: '.'

--- a/examples/policy_file/metadata.rb
+++ b/examples/policy_file/metadata.rb
@@ -1,0 +1,1 @@
+name 'policy_file'

--- a/examples/policy_file/recipes/default.rb
+++ b/examples/policy_file/recipes/default.rb
@@ -1,0 +1,1 @@
+log 'hello'

--- a/examples/policy_file/spec/install_spec.rb
+++ b/examples/policy_file/spec/install_spec.rb
@@ -1,0 +1,10 @@
+require 'chefspec'
+require 'chefspec/policyfile'
+
+describe 'policy_file::default' do
+  platform 'redhat'
+
+  it 'trivial test to show that policy files work' do
+    expect(chef_run).to write_log('hello')
+  end
+end

--- a/examples/policy_file_chefserver/Policyfile.rb
+++ b/examples/policy_file_chefserver/Policyfile.rb
@@ -1,0 +1,7 @@
+name 'fake_policy_to_show_chef_server_works'
+
+default_source :chef_server, 'http://localhost:8889'
+
+run_list 'policy_file_chefserver'
+
+cookbook 'policy_file_chefserver', path: '.'

--- a/examples/policy_file_chefserver/metadata.rb
+++ b/examples/policy_file_chefserver/metadata.rb
@@ -1,0 +1,1 @@
+name 'policy_file_chefserver'

--- a/examples/policy_file_chefserver/recipes/default.rb
+++ b/examples/policy_file_chefserver/recipes/default.rb
@@ -1,0 +1,1 @@
+log 'hello'

--- a/examples/policy_file_chefserver/spec/install_spec.rb
+++ b/examples/policy_file_chefserver/spec/install_spec.rb
@@ -1,0 +1,13 @@
+require 'chefspec'
+# includes custom setup/teardown code specifically for testing this in memory
+# not required when writing your own tests
+require_relative './policyfile_setup'
+require 'chefspec/policyfile'
+
+describe 'policy_file_chefserver::default' do
+  platform 'redhat'
+
+  it 'trivial test to show that policy files work' do
+    expect(chef_run).to write_log('hello')
+  end
+end

--- a/examples/policy_file_chefserver/spec/policyfile_setup.rb
+++ b/examples/policy_file_chefserver/spec/policyfile_setup.rb
@@ -1,0 +1,21 @@
+# When the default_source is a chef_server, we will use the ChefZero Server to test
+
+RSpec.configure do |config|
+  tmpdir = Dir.mktmpdir
+
+  config.before(:suite) do
+    # Setup the private key to authenticate against ChefZero Server
+    # inspired by ServerRunner#apply_chef_config!
+    path = File.join(tmpdir, 'client.pem')
+    File.open(path, 'wb') { |f| f.write(ChefZero::PRIVATE_KEY) }
+
+    Chef::Config[:client_key]  = path
+    Chef::Config[:client_name] = 'chefspec'
+    Chef::Config[:node_name]   = 'chefspec'
+  end
+
+  config.after(:suite) do
+    # cleanup private key
+    FileUtils.rm_rf(tmpdir)
+  end
+end

--- a/lib/chefspec/policyfile.rb
+++ b/lib/chefspec/policyfile.rb
@@ -1,6 +1,7 @@
 begin
   require 'chef-dk/policyfile_services/export_repo'
   require 'chef-dk/policyfile_services/install'
+  require 'chef-dk/configurable'
 rescue LoadError
   raise ChefSpec::Error::GemLoadError.new(gem: 'chef-dk', name: 'ChefDK')
 end
@@ -13,6 +14,7 @@ module ChefSpec
     end
 
     include Singleton
+    include ChefDK::Configurable
 
     def initialize
       @tmpdir = Dir.mktmpdir
@@ -26,7 +28,8 @@ module ChefSpec
 
       installer = ChefDK::PolicyfileServices::Install.new(
         policyfile: policyfile_path,
-        ui: ChefDK::UI.null
+        ui: ChefDK::UI.null,
+        config: chef_config
       )
 
       installer.run
@@ -52,6 +55,16 @@ module ChefSpec
     #
     def teardown!
       FileUtils.rm_rf(@tmpdir) if File.exist?(@tmpdir)
+    end
+
+    private
+
+    # chef_config calls this method to retrieve the path to the config file
+    # See ChefDK::Configurable#config_loader
+    def config
+      {
+        config_file: Chef::WorkstationConfigLoader.new(nil).config_location,
+      }
     end
   end
 end


### PR DESCRIPTION
When using `ChefSpec` and a `Policyfile`, we need to include `ChefDK::Configurable` so that when resolving cookbooks we have the context to know how to connect to the Chef Server, or other endpoint, and authenticate.

Fixes #934 