### PR TITLE
Require Ruby 2.3+, Chef 13+, and Fauxhai 6.11+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ bundler_args: --jobs 7 --retry 3
 
 matrix:
   include:
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 14.10.9'\""
+      rvm: 2.5.3
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 14.9.13'\""
+      rvm: 2.5.3
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 14.8.12'\""
+      rvm: 2.5.3
     - env: "GEMFILE_MOD=\"gem 'chef', '= 14.7.17'\""
       rvm: 2.5.3
     - env: "GEMFILE_MOD=\"gem 'chef', '= 14.6.47'\""

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ start_time = nil
 namespace :acceptance do |ns|
   begin
     Dir.foreach("examples") do |dir|
-      next if dir == '.' or dir == '..'
+      next if %w(. .. .DS_Store).include?(dir)
       desc "#{dir} acceptance tests"
       task dir.to_sym do
         start_time ||= Time.now

--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |s|
   s.files         = %w{LICENSE Rakefile Gemfile chefspec.gemspec} + Dir.glob("{lib,templates,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.2'
+  s.required_ruby_version = '>= 2.3'
 
-  s.add_dependency 'chef',    '>= 12.16.42'
-  s.add_dependency 'fauxhai', '>= 4'
+  s.add_dependency 'chef',    '>= 13'
+  s.add_dependency 'fauxhai', '>= 6.11'
   s.add_dependency 'rspec',   '~> 3.0'
 end


### PR DESCRIPTION
Remove support for EOL Ruby 2.2 and Chef 12

Also adds testing of the latest Chef 14 releases in Travis and fixes an issue on macOS systems where the rake acceptance testing would fail on a DS_Store file.