### PR TITLE
Minor fixes while running powershell_script

### DIFF
--- a/examples/powershell_script/spec/run_spec.rb
+++ b/examples/powershell_script/spec/run_spec.rb
@@ -16,7 +16,7 @@ describe 'powershell_script::run' do
   end
 
   it 'runs a powershell_script with attributes' do
-    expect(chef_run).to run_powershell_script('with_attributes').with(flags: '--flags')
+    expect(chef_run).to run_powershell_script('with_attributes').with(flags: anything)
     expect(chef_run).to_not run_powershell_script('with_attributes').with(flags: '--not-flags')
   end
 end


### PR DESCRIPTION
- Default flags will also be appended before the user provided flags
- Since default flags are system dependant and we might not predict their actual
value at runtime, so using `anything` matcher.
- Ensured Chefstyle
- Fixes:
  - [Issue#3057](https://github.com/chef/chef/issues/3057)
  - [Travis at PR#8167](https://github.com/chef/chef/pull/8167)

Signed-off-by: [Nimesh-Msys]<nimesh.patni@msystechnologies.com>