### PR TITLE
Platform detection for centos 6 is now 6.10

### DIFF
--- a/examples/spec_platform/spec/default_spec.rb
+++ b/examples/spec_platform/spec/default_spec.rb
@@ -31,6 +31,6 @@ describe 'spec_platform' do
 
   context 'with a partial version' do
     platform 'centos', '6'
-    it { is_expected.to write_log("test").with_message('Hello centos 6.9') }
+    it { is_expected.to write_log("test").with_message('Hello centos 6.10') }
   end
 end


### PR DESCRIPTION
@tas50 I'm not really sure what caused this to _start_ failing but it fixes the failing test