### PR TITLE
require shellout before using constants

### DIFF
--- a/lib/chefspec/api/stubs_for.rb
+++ b/lib/chefspec/api/stubs_for.rb
@@ -1,4 +1,5 @@
 require "chef/version"
+require "mixlib/shellout"
 
 module ChefSpec
   module API


### PR DESCRIPTION
relying on the dep to chef to pull in mixlib-shellout