### PR TITLE
Require Ruby 2.4+ and Chef 14+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 cache: bundler
-sudo: false
 
 before_install:
   - gem install bundler
@@ -16,6 +15,8 @@ bundler_args: --jobs 7 --retry 3
 
 matrix:
   include:
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.1.36'\""
+      rvm: 2.6.3
     - env: "GEMFILE_MOD=\"gem 'chef', '= 15.0.300'\""
       rvm: 2.6.3
     - env: "GEMFILE_MOD=\"gem 'chef', '= 14.13.11'\""
@@ -46,5 +47,3 @@ matrix:
       rvm: 2.5.1
     - env: "GEMFILE_MOD=\"gem 'chef', '= 14.0.202'\""
       rvm: 2.5.1
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 13.12.14'\""
-      rvm: 2.4.5

--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -21,9 +21,10 @@ Gem::Specification.new do |s|
   s.files         = %w{LICENSE Rakefile Gemfile chefspec.gemspec} + Dir.glob("{lib,templates,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.4'
 
-  s.add_dependency 'chef',    '>= 13'
+  s.add_dependency 'chef',    '>= 14'
+  s.add_dependency 'chef-cli'
   s.add_dependency 'fauxhai', '>= 6.11'
   s.add_dependency 'rspec',   '~> 3.0'
 end


### PR DESCRIPTION
Ruby 2.3 and Chef 13 are no longer supported platforms.

Signed-off-by: Tim Smith <tsmith@chef.io>