### PR TITLE
Switch to fauxhai-ng dep and release ChefSpec 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,16 @@ bundler_args: --jobs 7 --retry 3
 
 matrix:
   include:
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.3.14'\""
+      rvm: 2.6.4
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.2.20'\""
+      rvm: 2.6.4
     - env: "GEMFILE_MOD=\"gem 'chef', '= 15.1.36'\""
       rvm: 2.6.3
     - env: "GEMFILE_MOD=\"gem 'chef', '= 15.0.300'\""
       rvm: 2.6.3
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 14.14.14'\""
+      rvm: 2.5.7
     - env: "GEMFILE_MOD=\"gem 'chef', '= 14.13.11'\""
       rvm: 2.5.5
     - env: "GEMFILE_MOD=\"gem 'chef', '= 14.12.9'\""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG for ChefSpec
 
+## 9.0.0 (October 8, 2019)
+
+- The fauxhai dependency has been switched to the fauxhai-ng. Fauxhai-ng is the original source of the fauxhai project in the chefspec GitHub org, but with a new name. This is considered a major update as it forces users to upgrade to use fauxhai-ng >= 7.5 where as the previous ChefSpec release allowed for fauxhai >= 6.11.
+
 ## 8.0.1 (September 30, 2019)
 
 - Added back the ChefSpec report templates until the time that we fully remove the report feature.

--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'chef',    '>= 14'
   s.add_dependency 'chef-cli'
-  s.add_dependency 'fauxhai', '>= 6.11'
+  s.add_dependency 'fauxhai-ng', '>= 6.11'
   s.add_dependency 'rspec',   '~> 3.0'
 end

--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'chef',    '>= 14'
   s.add_dependency 'chef-cli'
-  s.add_dependency 'fauxhai-ng', '>= 6.11'
+  s.add_dependency 'fauxhai-ng', '>= 7.5'
   s.add_dependency 'rspec',   '~> 3.0'
 end

--- a/lib/chefspec/version.rb
+++ b/lib/chefspec/version.rb
@@ -1,3 +1,3 @@
 module ChefSpec
-  VERSION = '8.0.1'
+  VERSION = '9.0.0'
 end


### PR DESCRIPTION
The chefspec org on github contains the original source of the fauxhai project, but we no longer have access to release this gem under the fauxhai name. The fauxhai repo has been updated to push to the fauxhai-ng name, which maintains full compatibility with the CLI and library namespace of the original gem. This PR updates ChefSpec to use that new namespace and allow us to continue to pull in updates to the fauxhai project. This change is considered a major change as it forces users to pull in the 7.5+ fauxhai-ng release where as the previous dependency was on fauxhai >= 6.11