### PR TITLE
Add include_any_recipe matcher

### DIFF
--- a/lib/chefspec/api.rb
+++ b/lib/chefspec/api.rb
@@ -3,6 +3,7 @@ module ChefSpec
     autoload :Core, 'chefspec/api/core'
     autoload :Described, 'chefspec/api/described'
     autoload :DoNothing, 'chefspec/api/do_nothing'
+    autoload :IncludeAnyRecipe, 'chefspec/api/include_any_recipe'
     autoload :IncludeRecipe, 'chefspec/api/include_recipe'
     autoload :Link, 'chefspec/api/link'
     autoload :Notifications, 'chefspec/api/notifications'
@@ -19,6 +20,7 @@ module ChefSpec
       klass.include(ChefSpec::API::Core)
       klass.include(ChefSpec::API::Described)
       klass.include(ChefSpec::API::DoNothing)
+      klass.include(ChefSpec::API::IncludeAnyRecipe)
       klass.include(ChefSpec::API::IncludeRecipe)
       klass.include(ChefSpec::API::DoNothing)
       klass.include(ChefSpec::API::RenderFile)

--- a/lib/chefspec/api/include_any_recipe.rb
+++ b/lib/chefspec/api/include_any_recipe.rb
@@ -1,0 +1,24 @@
+module ChefSpec
+  module API
+    module IncludeAnyRecipe
+      #
+      # Assert that a Chef run includes any recipe.
+      #
+      #     include_recipe 'apache2::default'
+      #
+      # The Examples section demonstrates the different ways to test an
+      # +include_any_recipe+ directive with ChefSpec.
+      #
+      # @example Assert the Chef run did not include any recipes
+      #   expect(chef_run).not_to include_any_recipe
+      #
+      #
+      # @return [ChefSpec::Matchers::IncludeAnyRecipeMatcher]
+      #
+      def include_any_recipe
+        ChefSpec::Matchers::IncludeAnyRecipeMatcher.new
+      end
+      alias_method :include_any_recipes, :include_any_recipe
+    end
+  end
+end

--- a/lib/chefspec/matchers.rb
+++ b/lib/chefspec/matchers.rb
@@ -1,6 +1,7 @@
 module ChefSpec
   module Matchers
     require_relative 'matchers/do_nothing_matcher'
+    require_relative 'matchers/include_any_recipe_matcher'
     require_relative 'matchers/include_recipe_matcher'
     require_relative 'matchers/link_to_matcher'
     require_relative 'matchers/notifications_matcher'

--- a/lib/chefspec/matchers/include_any_recipe_matcher.rb
+++ b/lib/chefspec/matchers/include_any_recipe_matcher.rb
@@ -1,0 +1,51 @@
+module ChefSpec::Matchers
+  class IncludeAnyRecipeMatcher
+    def matches?(runner)
+      @runner = runner
+      !(loaded_recipes - run_list_recipes).empty?
+    end
+
+    def description
+      'include any recipe'
+    end
+
+    def failure_message
+      'expected to include any recipe'
+    end
+
+    def failure_message_when_negated
+      'expected not to include any recipes'
+    end
+
+    private
+
+    #
+    # The list of run_list recipes on the Chef run (normalized)
+    #
+    # @return [Array<String>]
+    #
+    def run_list_recipes
+      @runner.run_context.node.run_list.run_list_items.map { |x| with_default(x.name) }
+    end
+
+    #
+    # Automatically appends "+::default+" to recipes that need them.
+    #
+    # @param [String] name
+    #
+    # @return [String]
+    #
+    def with_default(name)
+      name.include?('::') ? name : "#{name}::default"
+    end
+
+    #
+    # The list of loaded recipes on the Chef run (normalized)
+    #
+    # @return [Array<String>]
+    #
+    def loaded_recipes
+      @runner.run_context.loaded_recipes.map { |name| with_default(name) }
+    end
+  end
+end

--- a/spec/unit/matchers/include_any_recipe_matcher_spec.rb
+++ b/spec/unit/matchers/include_any_recipe_matcher_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe ChefSpec::Matchers::IncludeAnyRecipeMatcher do
+  let(:node) { double('Chef::Node', run_list: run_list) }
+  let(:run_list) { double('Chef::RunList', run_list_items: run_list_items) }
+  let(:run_list_items) { [run_list_item_one] }
+  let(:run_list_item_one) { double('Chef::RunList::RunListItem', name: 'one') }
+  let(:run_list_item_two) { double('Chef::RunList::RunListItem', name: 'two') }
+  let(:loaded_recipes) { %w(one) }
+  let(:chef_run) { double('chef run', run_context: { loaded_recipes: loaded_recipes, node: node }) }
+
+  subject { described_class.new }
+
+  describe '#failure_message' do
+    it 'has the right value' do
+      subject.matches?(chef_run)
+      expect(subject.failure_message).to eq('expected to include any recipe')
+    end
+  end
+
+  describe '#failure_message_when_negated' do
+    it 'has the right value' do
+      subject.matches?(chef_run)
+      expect(subject.failure_message_when_negated).to eq('expected not to include any recipes')
+    end
+  end
+
+  describe '#description' do
+    it 'has the right value' do
+      subject.matches?(chef_run)
+      expect(subject.description).to eq('include any recipe')
+    end
+  end
+
+  describe '#matches?' do
+    context 'when 0 recipes are included' do
+      let(:loaded_recipes) { %w(one) }
+
+      it 'returns false' do
+        expect(subject.matches?(chef_run)).to be false
+      end
+    end
+
+    context 'when at least one recipe is included' do
+      let(:loaded_recipes) { %w(one two) }
+
+      it 'returns true' do
+        expect(subject.matches?(chef_run)).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Does this even make sense to folks? I've been dying for the following:

```ruby
expect(chef_run).not_to include_any_recipes
```

I feel crazy... but I also feel like this is useful.