### PR TITLE
Use ducktyping to safely stub provider

### DIFF
--- a/lib/chefspec/api/stubs_for.rb
+++ b/lib/chefspec/api/stubs_for.rb
@@ -35,7 +35,7 @@ module ChefSpec
       before do
         allow(StubsFor).to receive(:setup_stubs_for) do |object, type|
           type_stubs = _chefspec_stubs_for_registry[type]
-          resource_object = object.is_a?(Chef::Provider) ? object.new_resource : object
+          resource_object = object.respond_to?(:new_resource) ? object.new_resource : object
           stubs = type_stubs[nil] + type_stubs[resource_object.resource_name.to_s] + type_stubs[resource_object.to_s]
           stubs.each do |stub|
             instance_exec(object, &stub)


### PR DESCRIPTION
In some rare cases a ::Chef::Provider instance may not have the method `:new_resource`. In those cases Chefspec fails very early druing stub initialization.

The only actual case I know is the use of Poise `resource_provider_mixin`
See https://github.com/poise/poise/blob/master/lib/poise/utils/resource_provider_mixin.rb

I don't think this is a good pattern but it is used in some community cookbooks and that's very sad that Chefspec fails to test them.

I'm sorry I'm not adding regression test for that, since I'm not sure that reproducing the `resource_provider_mixin` is great, feel free to tell me if you want that I do it.

This should fix #954 