### PR TITLE
Use require_relative instead of require

### DIFF
--- a/lib/chefspec/extensions/chef/provider.rb
+++ b/lib/chefspec/extensions/chef/provider.rb
@@ -1,5 +1,5 @@
 require 'chef/provider'
-require 'chefspec/api'
+require_relative '../../api'
 
 Chef::Provider.prepend(Module.new do
   def self.name

--- a/lib/chefspec/extensions/chef/resource.rb
+++ b/lib/chefspec/extensions/chef/resource.rb
@@ -1,6 +1,6 @@
 require 'chef/resource'
 require 'chef/version'
-require 'chefspec/api'
+require_relative '../../api'
 
 #
 # Three concerns:

--- a/lib/chefspec/runner.rb
+++ b/lib/chefspec/runner.rb
@@ -1,4 +1,4 @@
-require "chefspec/solo_runner"
+require_relative "solo_runner"
 
 module ChefSpec
   # As we start to migrate back to only SoloRunner, include this alias for now.


### PR DESCRIPTION
require_relative is faster because it doesn't need to traverse the
filesystem

Signed-off-by: Tim Smith <tsmith@chef.io>