### PR TITLE
Update chefspec for after_resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,9 +518,10 @@ describe 'something' do
 end
 ```
 
-By default, stubs for the resource will also be set up on the `current_resource`
-object. This can be disabled by using `stubs_for_resource('my_custom_resource[something]', current_resource: false)`.
-You can also manually set stubs for only the `current_resource` using `stubs_for_current_resource`.
+By default, stubs for the resource will also be set up on the `current_resource` and `after_resource` objects that are
+created via `load_current_value`.  This can be disabled by using `stubs_for_resource('my_custom_resource[something]',
+current_value: false)`.  You can also manually set stubs for only the `current_resource` and `after_resource` objects using
+`stubs_for_current_value`.
 
 #### Ruby Code
 

--- a/examples/stubs_for/spec/default_spec.rb
+++ b/examples/stubs_for/spec/default_spec.rb
@@ -50,20 +50,20 @@ describe 'stubs_for' do
       end
 
       it do
-        stubs_for_current_resource('stubs_for_test[test]') do |res|
+        stubs_for_current_value('stubs_for_test[test]') do |res|
           allow(res).to receive_shell_out('this_is_not_a_cmd', stdout: 'asdf')
         end
         subject
       end
 
       it do
-        stubs_for_resource('stubs_for_test[test]', current_resource: false) do |res|
+        stubs_for_resource('stubs_for_test[test]', current_value: false) do |res|
           allow(res).to receive_shell_out('this_is_not_a_cmd', stdout: 'asdf')
         end
         expect { subject }.to raise_error ChefSpec::Error::ShellOutNotStubbed
       end
 
-      context 'with old-style load_current_resource' do
+      context 'with old-style load_current_value' do
         recipe do
           stubs_for_old 'test' do
             cmd 'this_is_not_a_cmd'
@@ -72,7 +72,7 @@ describe 'stubs_for' do
         end
 
         it do
-          stubs_for_current_resource('stubs_for_old[test]') do |res|
+          stubs_for_current_value('stubs_for_old[test]') do |res|
             allow(res).to receive_shell_out('this_is_not_a_cmd', stdout: 'asdf')
           end
           subject
@@ -150,16 +150,16 @@ describe 'stubs_for' do
         it { subject }
       end
 
-      context 'with stubs_for_current_resource' do
-        stubs_for_current_resource('stubs_for_test[test]') do |res|
+      context 'with stubs_for_current_value' do
+        stubs_for_current_value('stubs_for_test[test]') do |res|
           allow(res).to receive_shell_out('this_is_not_a_cmd', stdout: 'asdf')
         end
 
         it { subject }
       end
 
-      context 'with current_resource: false' do
-        stubs_for_resource('stubs_for_test[test]', current_resource: false) do |res|
+      context 'with current_value: false' do
+        stubs_for_resource('stubs_for_test[test]', current_value: false) do |res|
           allow(res).to receive_shell_out('this_is_not_a_cmd', stdout: 'asdf')
         end
         it { expect { subject }.to raise_error ChefSpec::Error::ShellOutNotStubbed }

--- a/lib/chefspec/api/stubs_for.rb
+++ b/lib/chefspec/api/stubs_for.rb
@@ -56,23 +56,25 @@ module ChefSpec
       #     expect(subject.some_method).to eq "asdf"
       #   end
       # @param target [String, nil] Resource name to inject, or nil for all resources.
-      # @param current_resource [Boolean] If true, also register stubs for current_resource objects on the same target.
+      # @param current_value [Boolean] If true, also register stubs for current_value objects on the same target.
       # @param block [Proc] A block taking the resource object as a parameter.
       # @return [void]
-      def stubs_for_resource(target=nil, current_resource: true, &block)
+      def stubs_for_resource(target=nil, current_value: true, current_resource: true, &block)
+        current_value = false if !current_resource
         _chefspec_stubs_for_registry[:resource][target] << block
-        stubs_for_current_resource(target, &block) if current_resource
+        stubs_for_current_value(target, &block) if current_value
       end
 
-      # Register stubs for current_resource objects.
+      # Register stubs for current_value objects.
       #
       # @see #stubs_for_resource
       # @param target [String, nil] Resource name to inject, or nil for all resources.
       # @param block [Proc] A block taking the resource object as a parameter.
       # @return [void]
-      def stubs_for_current_resource(target=nil, &block)
-        _chefspec_stubs_for_registry[:current_resource][target] << block
+      def stubs_for_current_value(target=nil, &block)
+        _chefspec_stubs_for_registry[:current_value][target] << block
       end
+      alias_method :stubs_for_current_resource, :stubs_for_current_value
 
       # Register stubs for provider objects.
       #
@@ -111,10 +113,11 @@ module ChefSpec
           before { stubs_for_resource(*args, &block) }
         end
 
-        # (see StubsFor#stubs_for_current_resource)
-        def stubs_for_current_resource(*args, &block)
-          before { stubs_for_current_resource(*args, &block) }
+        # (see StubsFor#stubs_for_current_value)
+        def stubs_for_current_value(*args, &block)
+          before { stubs_for_current_value(*args, &block) }
         end
+        alias_method :stubs_for_current_resource, :stubs_for_current_value
 
         # (see StubsFor#stubs_for_provider)
         def stubs_for_provider(*args, &block)

--- a/lib/chefspec/extensions/chef/resource.rb
+++ b/lib/chefspec/extensions/chef/resource.rb
@@ -21,7 +21,8 @@ module ChefSpec::Extensions::Chef::Resource
       # If we're directly inside a `load_current_resource`, this is probably
       # something like `new_resource.class.new` so we want to call this a current_resource,
       # Otherwise it's probably a normal resource instantiation.
-      mode = caller[1].include?("`load_current_resource'") ? :current_resource : :resource
+      mode = :resource
+      mode = :current_value if caller.any? { |x| x.include?("`load_current_resource'") || x.include?("`load_after_resource'") }
       ChefSpec::API::StubsFor.setup_stubs_for(self, mode)
     end
   end
@@ -33,7 +34,7 @@ module ChefSpec::Extensions::Chef::Resource
     super.tap do |dup_resource|
       # We're directly inside a load_current_resource, which is probably via
       # the load_current_value DSL system, so call this a current resource.
-      ChefSpec::API::StubsFor.setup_stubs_for(dup_resource, :current_resource) if stack.first.include?("`load_current_resource'")
+      ChefSpec::API::StubsFor.setup_stubs_for(dup_resource, :current_value) if caller.any? { |x| x.include?("`load_current_resource'") || x.include?("`load_after_resource'") }
     end
   end
 


### PR DESCRIPTION
This changes the chefspec API to target the "current_value" which
is short for "load_current_value" aka both the current_resource and
the after_resource objects.

This seems like the best API since the current_resource and the
after_resource shouldn't really be treated all that differently
(it is also not clear to me that anyone will really care at all
about chefspec'ing the after_resource -- chefspec has nothing to do
with testing the data collector output from the resource report).

So, I haven't included the ability to stub the current_resource
or after_resource separately, and made the current_value
stubbing backwards compatible with the current_resource stubbing.

At some point if it comes up we could consider splitting out
explicit stubbing of the current_resource + after_resource, but
that would probably be an API break when the current_resource
stubbing changes (again, though, I can't see how we need this
in chefspec and what people would be testing).

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>