### PR TITLE
#986, Warnings running on Ruby 2.7

### DIFF
--- a/lib/chefspec/extensions/chef/resource.rb
+++ b/lib/chefspec/extensions/chef/resource.rb
@@ -134,12 +134,11 @@ module ChefSpec::Extensions::Chef::Resource
       super
     end
 
-    def provides(name, *args, &block)
+    def provides(name, **options, &block)
       provides_names << name unless provides_names.include?(name)
       inject_actions(*allowed_actions)
       super
     end
-    ruby2_keywords(:provides) if respond_to?(:ruby2_keywords, true) 
 
     def action(sym, &block)
       inject_actions(sym)

--- a/lib/chefspec/extensions/chef/resource.rb
+++ b/lib/chefspec/extensions/chef/resource.rb
@@ -139,6 +139,7 @@ module ChefSpec::Extensions::Chef::Resource
       inject_actions(*allowed_actions)
       super
     end
+    ruby2_keywords(:provides) if respond_to?(:ruby2_keywords, true) 
 
     def action(sym, &block)
       inject_actions(sym)


### PR DESCRIPTION
Signed-off-by: Snehal Dwivedi <sdwivedi@msystechnologies.com>

## Description
- Fixed warnings running on Ruby 2.7 
- Reference [link ](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)
## Related Issue
Fixes:  https://github.com/chefspec/chefspec/issues/986
https://github.com/chef/chef-workstation/issues/1221
https://github.com/chef/chef-workstation/issues/1167
