### PR TITLE
Optimize our requires

### DIFF
--- a/examples/server/spec/node_spec.rb
+++ b/examples/server/spec/node_spec.rb
@@ -27,7 +27,7 @@ describe 'server::node' do
 
       node = chef_run.get_node('chefspec')
       expect(node['kernel']['name']).to eq('Linux')
-      expect(node['kernel']['release']).to match(/4.15.0-.*-.*/) # avoid failing when fauxhai data changes
+      expect(node['kernel']['release']).to match(/5.3.0-.*-.*/) # avoid failing when fauxhai data changes
       expect(node['kernel']['machine']).to eq('x86_64')
     end
   end

--- a/lib/chefspec/api/stubs_for.rb
+++ b/lib/chefspec/api/stubs_for.rb
@@ -1,5 +1,5 @@
 require "chef/version"
-require "mixlib/shellout"
+require "mixlib/shellout" unless defined?(Mixlib::ShellOut)
 
 module ChefSpec
   module API

--- a/lib/chefspec/file_cache_path_proxy.rb
+++ b/lib/chefspec/file_cache_path_proxy.rb
@@ -1,5 +1,5 @@
-require 'fileutils'
-require 'singleton'
+require 'fileutils' unless defined?(FileUtils)
+require 'singleton' unless defined?(Singleton)
 
 module ChefSpec
   class FileCachePathProxy

--- a/lib/chefspec/zero_server.rb
+++ b/lib/chefspec/zero_server.rb
@@ -122,7 +122,7 @@ module ChefSpec
                 require "chef_zero/data_store/memory_store_v2"
                 ChefZero::DataStore::MemoryStoreV2.new
               when :on_disk
-                require "tmpdir"
+                require "tmpdir" unless defined?(Dir.mktmpdir)
                 require "chef_zero/data_store/raw_file_store"
                 tmpdir = Dir.mktmpdir
                 ChefZero::DataStore::RawFileStore.new(Dir.mktmpdir)

--- a/spec/unit/solo_runner_spec.rb
+++ b/spec/unit/solo_runner_spec.rb
@@ -98,7 +98,7 @@ describe ChefSpec::SoloRunner do
       it 'sets the attributes from fauxhai' do
         expect(hash['os']).to eq('linux')
         expect(hash['languages']['ruby']['ruby_bin']).to eq('/usr/local/bin/ruby')
-        expect(hash['os_version']).to match(/4.15.0-.*-.*/) # avoid failing when fauxhai data changes
+        expect(hash['os_version']).to match(/5.3.0-.*-.*/) # avoid failing when fauxhai data changes
         expect(hash['fqdn']).to eq('fauxhai.local')
         expect(hash['domain']).to eq('local')
         expect(hash['ipaddress']).to eq('10.0.0.2')


### PR DESCRIPTION
rubygems require performance is quite terrible so we should only require
things when we need to.

Signed-off-by: Tim Smith <tsmith@chef.io>