### PR TITLE
Compatibility with optional named description for action

### DIFF
--- a/lib/chefspec/extensions/chef/resource.rb
+++ b/lib/chefspec/extensions/chef/resource.rb
@@ -140,7 +140,7 @@ module ChefSpec::Extensions::Chef::Resource
       super
     end
 
-    def action(sym, &block)
+    def action(sym, description: nil, &block)
       inject_actions(sym)
       super
     end


### PR DESCRIPTION
This introduces compatibility for [this change](chef#109052)

This is a backwards compatible signature change for `ChefSpec::Extensions::Chef::Resource#acttion` so it should be safe to merge independently of chef#10952

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>