### PR TITLE
Make action description backward compat too

### DIFF
--- a/lib/chefspec/extensions/chef/resource.rb
+++ b/lib/chefspec/extensions/chef/resource.rb
@@ -142,7 +142,7 @@ module ChefSpec::Extensions::Chef::Resource
 
     def action(sym, description: nil, &block)
       inject_actions(sym)
-      super
+      super(sym, &block)
     end
 
     def allowed_actions(*actions)


### PR DESCRIPTION
We can't call `super` without arguments, because not all versions of `chef` know about the `description` parameter. 

When all versions are current, this change does mean that action description will not be passed into the Chef resource even though it would be supported, but in the context of `chefspec` that won't affect its functionality.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>