### PR TITLE
Require Ruby 2.5 / Chef 15 or later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7' ]
+        ruby: [ '2.5', '2.6', '2.7' ]
     name: Lint & Test with Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ bundler_args: --jobs 7 --retry 3
 
 matrix:
   include:
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 16.9.32'\""
+      rvm: 2.7.2
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 16.8.14'\""
+      rvm: 2.7.2
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 16.7.61'\""
+      rvm: 2.7.2
     - env: "GEMFILE_MOD=\"gem 'chef', '= 16.6.14'\""
       rvm: 2.7.2
     - env: "GEMFILE_MOD=\"gem 'chef', '= 16.5.77'\""
@@ -29,35 +35,7 @@ matrix:
       rvm: 2.7.1
     - env: "GEMFILE_MOD=\"gem 'chef', '= 16.0.287'\""
       rvm: 2.7.1
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.14.0'\""
+    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.15.0'\""
       rvm: 2.6.6
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.13.8'\""
-      rvm: 2.6.5
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.12.22'\""
-      rvm: 2.6.5
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.11.8'\""
-      rvm: 2.6.5
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.10.12'\""
-      rvm: 2.6.5
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.9.17'\""
-      rvm: 2.6.5
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.8.23'\""
-      rvm: 2.6.4
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.7.30'\""
-      rvm: 2.6.4
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.6.10'\""
-      rvm: 2.6.4
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.5.17'\""
-      rvm: 2.6.4
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.4.45'\""
-      rvm: 2.6.4
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.3.14'\""
-      rvm: 2.6.4
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.2.20'\""
-      rvm: 2.6.4
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 15.1.36'\""
-      rvm: 2.6.3
     - env: "GEMFILE_MOD=\"gem 'chef', '= 15.0.300'\""
       rvm: 2.6.3
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 14.14.14'\""
-      rvm: 2.5.7

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,12 @@ else
   gem 'ohai', git: "https://github.com/chef/ohai"
 end
 
+# TODO: remove when we drop ruby 2.5
+if Gem.ruby_version < Gem::Version.new("2.6")
+  # 16.7.23 required ruby 2.6+
+  gem "chef-utils", "< 16.7.23"
+end
+
 # If you want to load debugging tools into the bundle exec sandbox,
 # add these additional dependencies into Gemfile.local
 eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ ChefSpec runs your cookbooks locally while skipping making actual changes. This 
 
 ## Important Notes
 
-- **ChefSpec requires Ruby 2.2 or later and Chef 12.14.89 or later!**
+- **ChefSpec requires Ruby 2.5 or later and Chef 15 or later!**
 - **This documentation corresponds to the master branch, which may be unreleased. Please check the README of the latest git tag or the gem's source for your version's documentation!**
 
 **ChefSpec aims to maintain compatibility with at least the two most recent minor versions of Chef.** If you are running an older version of Chef it may work, or you will need to run an older version of ChefSpec.

--- a/chefspec.gemspec
+++ b/chefspec.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |s|
   s.files         = %w{LICENSE Rakefile Gemfile chefspec.gemspec} + Dir.glob("{lib,templates,spec}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.4'
+  s.required_ruby_version = '>= 2.5'
 
-  s.add_dependency 'chef',    '>= 14'
+  s.add_dependency 'chef', '>= 15'
   s.add_dependency 'chef-cli'
   s.add_dependency 'fauxhai-ng', '>= 7.5'
   s.add_dependency 'rspec',   '~> 3.0'


### PR DESCRIPTION
Drop support for EOL chef and EOL ruby

Signed-off-by: Tim Smith <tsmith@chef.io>