### PR TITLE
Ruby-3.0 fixes and CI changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,27 +1,44 @@
 name: CI
+
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
     branches:
-    - master
+      - master
+  schedule:
+    - cron:  '42 4 * * *'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
     name: Lint & Test with Ruby ${{ matrix.ruby }}
     steps:
+      - run: |
+          if [ "${{ matrix.ruby }}" = "2.5" ]; then
+            echo "GEMFILE_MOD=gem 'chef', '= 15.15.0'" >> $GITHUB_ENV
+          elif [ "${{ matrix.ruby }}" = "2.6" ]; then
+            echo "GEMFILE_MOD=gem 'chef', '= 15.15.0'" >> $GITHUB_ENV
+          elif [ "${{ matrix.ruby }}" = "2.7" ]; then
+            echo "GEMFILE_MOD=gem 'chef', '= 16.9.32'" >> $GITHUB_ENV
+          fi
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
       - name: Setup Ruby environment
         run: |
           gem install bundler
           bundle install --jobs 4 --retry 3
-      - name: Testing & Linting
-        run: bundle exec rake
+      - run: bundle exec rake unit
+        if: always()
+      - run: bundle exec rake acceptance
+        if: always()
+      - run: bundle exec rake style
+        if: always()

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,3 +2,6 @@ AllCops:
   TargetRubyVersion: 2.5
   Exclude:
     - "examples/**/*"
+    - "spec/tmp/**/*"
+    - "tmp/**/*"
+    - "vendor/**/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ bundler_args: --jobs 7 --retry 3
 
 matrix:
   include:
+    - rvm: 3.0.0
     - env: "GEMFILE_MOD=\"gem 'chef', '= 16.9.32'\""
       rvm: 2.7.2
     - env: "GEMFILE_MOD=\"gem 'chef', '= 16.8.14'\""
@@ -24,16 +25,6 @@ matrix:
     - env: "GEMFILE_MOD=\"gem 'chef', '= 16.6.14'\""
       rvm: 2.7.2
     - env: "GEMFILE_MOD=\"gem 'chef', '= 16.5.77'\""
-      rvm: 2.7.1
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 16.4.41'\""
-      rvm: 2.7.1
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 16.3.45'\""
-      rvm: 2.7.1
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 16.2.73'\""
-      rvm: 2.7.1
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 16.1.16'\""
-      rvm: 2.7.1
-    - env: "GEMFILE_MOD=\"gem 'chef', '= 16.0.287'\""
       rvm: 2.7.1
     - env: "GEMFILE_MOD=\"gem 'chef', '= 15.15.0'\""
       rvm: 2.6.6

--- a/lib/chefspec/api/stubs_for.rb
+++ b/lib/chefspec/api/stubs_for.rb
@@ -109,8 +109,8 @@ module ChefSpec
 
       module ClassMethods
         # (see StubsFor#stubs_for_resource)
-        def stubs_for_resource(*args, &block)
-          before { stubs_for_resource(*args, &block) }
+        def stubs_for_resource(*args, **kwargs, &block)
+          before { stubs_for_resource(*args, **kwargs, &block) }
         end
 
         # (see StubsFor#stubs_for_current_value)

--- a/lib/chefspec/coverage.rb
+++ b/lib/chefspec/coverage.rb
@@ -30,12 +30,12 @@ module ChefSpec
       @filters    = {}
       @outputs    = []
       add_output do |report|
-        begin
-          erb = Erubis::Eruby.new(File.read(@template))
-          puts erb.evaluate(report)
-        rescue NameError => e
-          raise Error::ErbTemplateParseError.new(original_error: e.message)
-        end
+
+        erb = Erubis::Eruby.new(File.read(@template))
+        puts erb.evaluate(report)
+      rescue NameError => e
+        raise Error::ErbTemplateParseError.new(original_error: e.message)
+
       end
       @template = ChefSpec.root.join("templates", "coverage", "human.erb")
     end


### PR DESCRIPTION
Still only partial conversion to GH actions.

The older chef-16 tests have been removed due to issues with ohai-16 not
being pinned and blowing up due to lack of recent enough chef-utils.

Those tests weren't providing enough value to continue to maintain them.