### PR TITLE
Fixes #1009

### DIFF
--- a/lib/chefspec/policyfile.rb
+++ b/lib/chefspec/policyfile.rb
@@ -27,9 +27,12 @@ module ChefSpec
         policyfile_path = File.join(Dir.pwd, "Policyfile.rb")
       end
 
+      Chef::WorkstationConfigLoader.new(nil).load
+
       installer = ChefCLI::PolicyfileServices::Install.new(
         policyfile: policyfile_path,
-        ui: ChefCLI::UI.null
+        ui: ChefCLI::UI.null,
+        config: Chef::Config
       )
 
       installer.run


### PR DESCRIPTION
I wish I could tell you why this works, but I can't. I largely poked around the `chef-cli` and blindly copied the patterns from there. I was mainly comparing the differences between chefspec's use of the `PolicyfileServices::Install` class and chef-cli during the `chef install`/`chef update` commands. It seemed pretty clear based on the exception and the code that it was missing the chef config.

References:

- https://github.com/chef/chef-cli/blob/master/lib/chef-cli/configurable.rb#L50-L65