### PR TITLE
Changing resource check order, identity check fails for optional property 

### DIFF
--- a/lib/chefspec/solo_runner.rb
+++ b/lib/chefspec/solo_runner.rb
@@ -208,7 +208,7 @@ module ChefSpec
     #
     def find_resource(type, name, action = nil)
       resource_collection.all_resources.reverse_each.find do |resource|
-        resource.declared_type == type.to_sym && (name === resource.identity || name === resource.name) && (action.nil? || resource.performed_action?(action))
+        resource.declared_type == type.to_sym && (name === resource.name || name === resource.identity) && (action.nil? || resource.performed_action?(action))
       end
     end
 


### PR DESCRIPTION
…dentity field is optional in resource

Signed-off-by: smriti <sgarg@msystechnologies.com>
For spec like this : - 
```
it 'deletes a cron entry named reboot2' do
   expect(chef_run).to delete_cron('reboot2')
end
```

This check was making chefspec fail for cron resource, where identity field - `command` is required for only action `create`. In case the spec action is delete, an execption is raised from `Chef Resource` class like this - 

```
Chef::Exceptions::ValidationFailed:
command is a required property
```
Even though logically `command` is required only for `create`action. In current find_resource method - the identity check is before name check for a resource.. so if a scenario is like Cron Resource .. where property definition is : - 
```
property :command, String,
  description: "The command to be run, or the path to a file that contains the command to be run.",
  identity: true,
  required: [:create]
  ```
An exception will always be thrown, even without going to the next check which is on name. Hence I am changing the order of checks to handle above condition. 

## Issue resolved - 
https://github.com/chef/chef/issues/11030