### PR TITLE
Fix Hash timeout hacky fix

### DIFF
--- a/spec/support/hash.rb
+++ b/spec/support/hash.rb
@@ -5,7 +5,7 @@
 #
 class Hash
   # Like, seriously Windows?
-  undef_method(:timeout)
+  undef_method(:timeout) if method_defined?(:timeout)
 
   #
   # Monkey-patch to allow mash-style look ups for tests


### PR DESCRIPTION
Don't know why this suddenly started failing but suspect it was ruby 3
